### PR TITLE
fix(recruit_commands): add null check in getTargetAccountIdByName to …

### DIFF
--- a/src/recruit_commands.cpp
+++ b/src/recruit_commands.cpp
@@ -83,7 +83,13 @@ static void getTargetAccountIdByName(std::string& name, uint32& accountId)
 {
     QueryResult result = CharacterDatabase.Query("SELECT `account` FROM `characters` WHERE `name`='{}'", name);
 
-    accountId = (*result)[0].Get<int32>();
+    if (!result)
+    {
+        accountId = 0;
+        return;
+    }
+
+    accountId = (*result)[0].Get<uint32>();
 }
 
 using namespace Acore::ChatCommands;


### PR DESCRIPTION
…prevent server crash

If the character name does not exist in the database, QueryResult is null. Dereferencing it without a guard causes an immediate server crash. Also fixes the return type from int32 to uint32 to match the accountId field.