### PR TITLE
feat(logging): replace DB audit table with file-based logging

### DIFF
--- a/conf/mod_recruit_friend.conf.dist
+++ b/conf/mod_recruit_friend.conf.dist
@@ -27,3 +27,23 @@ RecruitFriend.cooldownEnabled = true
 #
 
 RecruitFriend.cooldownValue = 300000
+
+#
+#  RecruitFriend audit log
+#
+#    Appender.RecruitFriend
+#        Writes command usage to a dedicated log file.
+#        Type 2 = File | LogLevel 4 = Info | Flags 1 = Timestamp prefix
+#        File: RecruitFriend.log (created inside LogsDir from worldserver.conf)
+#        Mode: a = Append (history survives restarts)
+#
+
+Appender.RecruitFriend=2,4,1,RecruitFriend.log,a
+
+#
+#    Logger.module.recruitfriend
+#        Routes the recruit friend log category to the appender above.
+#        LogLevel 4 = Info
+#
+
+Logger.module.recruitfriend=4,RecruitFriend

--- a/data/sql/db-auth/base/recruit_info.sql
+++ b/data/sql/db-auth/base/recruit_info.sql
@@ -1,10 +1,1 @@
-CREATE TABLE IF NOT EXISTS `recruit_info` (
-  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `accountId` int(11) unsigned NOT NULL,
-  `accountName` varchar(32) NOT NULL DEFAULT '',
-  `characterName` varchar(12) NOT NULL DEFAULT '',
-  `ip` varchar(15) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `command` varchar(5) NOT NULL DEFAULT '',
-  `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+-- recruit_info table removed; logging is handled by RecruitFriend.log (see mod_recruit_friend.conf.dist)

--- a/data/sql/db-auth/updates/2026_06_01_00_recruit_friend.sql
+++ b/data/sql/db-auth/updates/2026_06_01_00_recruit_friend.sql
@@ -1,0 +1,2 @@
+-- Logging moved from recruit_info table to file-based system (RecruitFriend.log)
+DROP TABLE IF EXISTS `recruit_info`;

--- a/src/recruit_commands.cpp
+++ b/src/recruit_commands.cpp
@@ -8,8 +8,8 @@
 #include "Player.h"
 #include "Config.h"
 #include "Chat.h"
-#include "AccountMgr.h"
 #include "LoginDatabase.h"
+#include "Log.h"
 #include <map>
 
 enum RecruitFriendTexts
@@ -57,19 +57,6 @@ public:
             recruitFriend.commandCooldown.erase(it);
     }
 };
-
-static void registerQuery(ChatHandler* handler, char const* commandType)
-{
-    uint32 myAccountId = handler->GetSession()->GetAccountId();
-
-    std::string accountName;
-    AccountMgr::GetName(myAccountId, accountName);
-
-    std::string characterName = handler->GetSession()->GetPlayerName();
-    std::string ipAccount = handler->GetSession()->GetRemoteAddress();
-
-    LoginDatabase.Execute("INSERT INTO `recruit_info` (`accountId`, `accountName`, `characterName`, `ip`, `command`) VALUES ({}, '{}', '{}', '{}', '{}')", myAccountId, accountName, characterName, ipAccount, commandType);
-}
 
 // Returns true if the command is still on cooldown (message sent), false if the player can proceed.
 static bool isCommandOnCooldown(ChatHandler* handler, uint32 accountId)
@@ -174,7 +161,8 @@ class RecruitCommandscript : public CommandScript
                 recruitFriend.commandCooldown[myAccountId] = std::time(nullptr);
             }
 
-            registerQuery(handler, "add");
+            LOG_INFO("module.recruitfriend", "[RecruitFriend] Account: {} | Character: {} | IP: {} | Command: add | Target account: {}",
+                myAccountId, handler->GetSession()->GetPlayerName(), handler->GetSession()->GetRemoteAddress(), targetAccountId);
 
             QueryResult result = LoginDatabase.Query("SELECT 1 FROM `account` WHERE `recruiter` <> 0 AND `id`={}", myAccountId);
 
@@ -208,7 +196,8 @@ class RecruitCommandscript : public CommandScript
                 recruitFriend.commandCooldown[myAccountId] = std::time(nullptr);
             }
 
-            registerQuery(handler, "reset");
+            LOG_INFO("module.recruitfriend", "[RecruitFriend] Account: {} | Character: {} | IP: {} | Command: reset",
+                myAccountId, handler->GetSession()->GetPlayerName(), handler->GetSession()->GetRemoteAddress());
 
             QueryResult result = LoginDatabase.Query("SELECT `recruiter` FROM `account` WHERE `id`={}", myAccountId);
 
@@ -242,7 +231,8 @@ class RecruitCommandscript : public CommandScript
                 recruitFriend.commandCooldown[myAccountId] = std::time(nullptr);
             }
 
-            registerQuery(handler, "view");
+            LOG_INFO("module.recruitfriend", "[RecruitFriend] Account: {} | Character: {} | IP: {} | Command: view",
+                myAccountId, handler->GetSession()->GetPlayerName(), handler->GetSession()->GetRemoteAddress());
 
             QueryResult result = LoginDatabase.Query("SELECT `recruiter` FROM `account` WHERE `id`={}", myAccountId);
 


### PR DESCRIPTION
- Remove registerQuery and AccountMgr dependency; audit writes to recruit_info table are replaced by LOG_INFO calls using the module.recruitfriend category
- Add Appender.RecruitFriend and Logger.module.recruitfriend to mod_recruit_friend.conf.dist; log file is RecruitFriend.log, created inside the LogsDir configured in worldserver.conf
- Clear db-auth/base/recruit_info.sql for fresh installs
- Add db-auth/updates/2026_06_01_00_recruit_friend.sql to drop the recruit_info table on existing installations