### PR TITLE
Add RecruitFriend.allowSelfRecruit config option

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -47,6 +47,14 @@ RecruitAFriend.MaxLevel = 60
 RecruitAFriend.MaxDifference = 4
 ```
 
+## Recruiting yourself
+
+By default an account cannot recruit itself. Set `RecruitFriend.allowSelfRecruit = true`
+in `mod_recruit_friend.conf` to lift that restriction — useful with modules like
+[mod-playerbots](https://github.com/liyunfan1223/mod-playerbots), where a "recruited"
+character can be an alt bot on your own account, letting you get the Recruit-A-Friend
+experience multiplier while soloing with a bot alt.
+
 ## Available commands
 
 - `.recruit add <characterName>`. Ex: `.recruit add Pango`

--- a/conf/mod_recruit_friend.conf.dist
+++ b/conf/mod_recruit_friend.conf.dist
@@ -29,6 +29,16 @@ RecruitFriend.cooldownEnabled = true
 RecruitFriend.cooldownValue = 300000
 
 #
+# Allow an account to recruit itself
+#   Useful with modules like mod-playerbots, where a "recruited" character can
+#   be an alt bot on the same account, letting you get the Recruit-A-Friend
+#   experience multiplier while soloing with a bot alt.
+# default: false
+#
+
+RecruitFriend.allowSelfRecruit = false
+
+#
 #  RecruitFriend audit log
 #
 #    Appender.RecruitFriend

--- a/src/recruit_commands.cpp
+++ b/src/recruit_commands.cpp
@@ -29,7 +29,7 @@ enum RecruitFriendTexts : uint32
 struct RecruitFriendStruct
 {
     std::map<uint32, std::time_t> commandCooldown;
-    bool announceEnable, commandEnable, cooldownEnabled;
+    bool announceEnable, commandEnable, cooldownEnabled, allowSelfRecruit;
     uint32 cooldownValue;
 };
 
@@ -144,7 +144,7 @@ class RecruitCommandscript : public CommandScript
 
             uint32 myAccountId = handler->GetSession()->GetAccountId();
 
-            if (targetAccountId == myAccountId)
+            if (targetAccountId == myAccountId && !recruitFriend.allowSelfRecruit)
             {
                 handler->PSendModuleSysMessage("mod-recruit-friend", RECRUIT_FRIEND_TARGET_ONESELF);
                 return true;
@@ -269,6 +269,7 @@ public:
         recruitFriend.commandEnable = sConfigMgr->GetOption<bool>("RecruitFriend.enable", true);
         recruitFriend.cooldownEnabled = sConfigMgr->GetOption<bool>("RecruitFriend.cooldownEnabled", true);
         recruitFriend.cooldownValue = sConfigMgr->GetOption<uint32>("RecruitFriend.cooldownValue", 300000);
+        recruitFriend.allowSelfRecruit = sConfigMgr->GetOption<bool>("RecruitFriend.allowSelfRecruit", false);
     }
 };
 


### PR DESCRIPTION
## Summary
- Adds `RecruitFriend.allowSelfRecruit` (default `false`) to gate the existing "cannot recruit yourself" check.
- Default behavior is unchanged for everyone else.
- When enabled, `.recruit add <name>` on a character belonging to your own account succeeds silently, exactly like recruiting a different account.

## Why
Servers running [mod-playerbots](https://github.com/liyunfan1223/mod-playerbots) let players control an alt as a bot on their own account (`AiPlayerbot.AllowAccountBots`). Since the account-level RaF check in AzerothCore core (`Player::GetsRecruitAFriendBonus`) only compares `account.recruiter` against the grouped member's account id, this works correctly for a same-account "recruiter" once the module stops blocking it at the command level — letting players get the Recruit-A-Friend XP multiplier while soloing with a bot alt.

## Test plan
- [ ] Build worldserver with the module and confirm it compiles
- [ ] With `RecruitFriend.allowSelfRecruit = false` (default), `.recruit add <ownAltName>` still shows the existing "cannot recruit yourself" message
- [ ] With `RecruitFriend.allowSelfRecruit = true`, `.recruit add <ownAltName>` succeeds and sets `account.recruiter` to the same account id
- [ ] `.recruit view` / `.recruit reset` behave normally afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)